### PR TITLE
Release file separator fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.nimbusframework</groupId>
     <artifactId>nimbus-deployment-maven-plugin</artifactId>
-    <version>0.13.5-SNAPSHOT</version>
+    <version>0.13.5</version>
 
     <packaging>maven-plugin</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.nimbusframework</groupId>
     <artifactId>nimbus-deployment-maven-plugin</artifactId>
-    <version>0.13.5</version>
+    <version>0.13.6-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 

--- a/src/main/java/services/FileService.kt
+++ b/src/main/java/services/FileService.kt
@@ -11,10 +11,10 @@ import java.nio.file.Paths
 class FileService(private val logger: Log) {
 
     private val tempDir = System.getProperty("java.io.tmpdir")
-    private val tempPath = if (tempDir.endsWith(File.pathSeparator)) {
-        tempDir + "nimbus" + File.pathSeparator
+    private val tempPath = if (tempDir.endsWith(File.separator)) {
+        tempDir + "nimbus" + File.separator
     } else {
-        tempDir + File.pathSeparator + "nimbus" + File.pathSeparator
+        tempDir + File.separator + "nimbus" + File.separator
     }
 
     fun getFileText(path: String): String {
@@ -49,7 +49,7 @@ class FileService(private val logger: Log) {
     companion object {
         @JvmStatic
         fun addDirectorySeparatorIfNecessary(path: String): String {
-            if (path.endsWith(File.separatorChar)) return path
+            if (path.endsWith(File.separator)) return path
             return "$path${File.separator}"
         }
     }


### PR DESCRIPTION
Release fix for wrong separator being used: `File.fileSeparator` was used instead of `File.separator`